### PR TITLE
add goreleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on: 
+  push:
+    branches: [ main ]
+  create:
 
 jobs:
   test:
@@ -19,3 +22,33 @@ jobs:
         run: go get .
       - name: Test
         run: make test
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          # 'latest', 'nightly', or a semver
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,46 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tic-tac-toe
 
-go 1.22.4
+go 1.22
 
 require (
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203


### PR DESCRIPTION
## issue
 Add release workflow using GoReleaser #1

## description
I have added the GitHub workflow for goreleaser. 

## new behavior
Few important things to note are following:
* The pipeline is triggered when a new tag is created. I notice that the goreleaser exits with panic if HEAD is not atttached to any tag.
* The tag must be of version pattern(For example `v0.1.1`)
* You can create a tag locally and push using the following commands
``` bash
git tag -a v0.1.1
git push --tags
```
It will result in a new release with title as `v0.1.1` and would be shown as if GitHub Workflow has created it. Also description is change logs from commits. You may see it in action in the release section fork I made `v0.1.1`.
* Alternatively you may create a new release from website. The release will be replaced with a new release after build. The description of the release remains same while title does change to version.  You can create the release as pre-release which automatically gets converted to latest after build. You may see it in action in the release section fork I made `v0.1.2`.